### PR TITLE
Increase build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 7 %}
+{% set build = 8 %}
 {% set name = "lammps" %}
 {% set version = "stable_2Aug2023" %}
 {% set version_plugins = "stable_2Aug2023" %}


### PR DESCRIPTION
In https://github.com/conda-forge/lammps-feedstock/pull/170 and in https://github.com/conda-forge/lammps-feedstock/pull/172 the build number was set to `7`. So there are now two different builds available with the build number `7`. So I increase the build number to `8`. 